### PR TITLE
Reorganized into Structs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             inherit system overlays;
           };
           rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-          nativeBuildInputs = with pkgs; [ rustToolchain pkg-config ];
+          nativeBuildInputs = with pkgs; [ rustToolchain pkg-config lldb ];
           buildInputs = with pkgs; [ openssl sqlite sqlx-cli ];
         in
         rec {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
-use clap::{Parser, Args};
+use clap::Parser;
 use reqwest::Url;
+
+use crate::ttp::Ttp;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -28,16 +30,4 @@ pub struct Config {
     pub fhir_output_url: Url,
     #[clap(long, env)]
     pub fhir_output_credentials: String,
-}
-
-#[derive(Args, Clone, Debug)]
-#[group(requires = "url", requires = "api_key", requires = "project_id_system")]
-pub struct Ttp {
-    #[arg(required = false, long = "institute-ttp-url", env = "INSTITUTE_TTP_URL")]
-    pub url: Url,
-    #[arg(required = false, long = "institute-ttp-api-key", env = "INSTITUTE_TTP_API_KEY")]
-    pub api_key: String,
-    // defines the identifier to safe in the project database
-    #[arg(required = false, long, env)]
-    pub project_id_system: String,
 }

--- a/src/fhir.rs
+++ b/src/fhir.rs
@@ -98,17 +98,14 @@ impl FhirServer {
     }
 }
 
-pub trait PseudonymizableExt: Sized {
+pub trait PatientExt: Sized {
     fn pseudonymize(self) -> axum::response::Result<Self>;
-}
-
-pub trait LinkableExt: Sized {
     fn add_id_request(self, id: String) -> axum::response::Result<Self>;
     fn get_exchange_identifier(&self) -> Option<&Identifier>;
     fn contains_exchange_identifier(&self) -> bool;
 }
 
-impl LinkableExt for Patient {
+impl PatientExt for Patient {
     fn add_id_request(mut self, id: String) -> axum::response::Result<Self> {
         let request = Identifier::builder()
             .r#use(IdentifierUse::Secondary)
@@ -143,9 +140,7 @@ impl LinkableExt for Patient {
             .flatten()
             .any(|x| x.system.as_ref() == Some(&CONFIG.exchange_id_system))
     }
-}
 
-impl PseudonymizableExt for Patient {
     fn pseudonymize(self) -> axum::response::Result<Self> {
         let id = self.id.clone().unwrap();
         let exchange_identifier_pos = self
@@ -168,7 +163,7 @@ impl PseudonymizableExt for Patient {
                 )
             })?;
         Ok(pseudonymized_patient)
-    } 
+    }
 }
 
 impl Into<Bundle> for DataRequestPayload {
@@ -207,7 +202,7 @@ impl Into<Bundle> for DataRequestPayload {
 
 #[cfg(test)]
 mod tests {
-    use crate::fhir::LinkableExt;
+    use crate::fhir::PatientExt;
     use fhir_sdk::r4b::{codes::IdentifierUse, resources::Patient};
 
     #[test]

--- a/src/fhir.rs
+++ b/src/fhir.rs
@@ -1,9 +1,131 @@
 use chrono::NaiveDate;
-use fhir_sdk::r4b::{resources::{Bundle, BundleEntry, BundleEntryRequest, Consent, Patient, Resource}, codes::IdentifierUse, types::Identifier};
+use clap::Args;
+use fhir_sdk::r4b::{
+    codes::IdentifierUse,
+    resources::{Bundle, BundleEntry, BundleEntryRequest, Consent, Patient, Resource},
+    types::Identifier,
+};
 use reqwest::{header, StatusCode, Url};
 use tracing::{debug, error, warn};
 
 use crate::CONFIG;
+
+#[derive(Args, Clone, Debug)]
+#[group(requires = "url", requires = "credentials")]
+pub struct FhirServer {
+    #[arg(required = false)]
+    pub url: Url,
+    #[arg(required = false)]
+    pub credentials: String,
+}
+
+impl FhirServer {
+    pub async fn post_data_request(
+        &self,
+        patient: Patient,
+        consent: Consent,
+    ) -> Result<String, (StatusCode, &'static str)> {
+        let bundle_endpoint = format!("{}fhir", self.url);
+        debug!("Posting request for DIC to {}", self.url);
+
+        let patient_entry = BundleEntry::builder()
+            .resource(Resource::from(patient))
+            .request(
+                BundleEntryRequest::builder()
+                    .method(fhir_sdk::r4b::codes::HTTPVerb::Post)
+                    .url(String::from("/Patient"))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let consent_entry = BundleEntry::builder()
+            .resource(Resource::from(consent))
+            .request(
+                BundleEntryRequest::builder()
+                    .method(fhir_sdk::r4b::codes::HTTPVerb::Post)
+                    .url(String::from("/Consent"))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let payload_bundle = Bundle::builder()
+            .r#type(fhir_sdk::r4b::codes::BundleType::Transaction)
+            .entry(vec![Some(patient_entry), Some(consent_entry)])
+            .build()
+            .unwrap();
+
+        let response = reqwest::Client::new()
+            .post(bundle_endpoint)
+            .header(header::CONTENT_TYPE, "application/json+fhir")
+            .json(&payload_bundle)
+            .send()
+            .await
+            .map_err(|err| {
+                warn!("Unable to connect to fhir server: {}", err);
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Unable to connect to consent fhir server. Please try later.",
+                )
+            })
+            .unwrap();
+
+        if response.status().is_client_error() | response.status().is_server_error() {
+            error!(
+                "Unable to push request to server: status={}",
+                response.status()
+            );
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                "Unable to create consent in consent server. Please contact your administrator.",
+            ));
+        };
+
+        let bundle = response.json::<Bundle>()
+            .await
+            .map_err(|err| {
+                error!("Unable to parse consent returned by fhir server: {}", err);
+                (StatusCode::BAD_GATEWAY, "Unable to parse consent returned by consent server. Please contact your administrator.")
+            }).unwrap();
+
+        Ok(bundle
+            .id
+            .clone()
+            .expect("Consent Server returned bundle without id."))
+    }
+
+    // get data from fhir server that updated after a specified date
+    pub async fn pull_new_data(&self, last_update: NaiveDate) -> Result<Bundle, String> {
+        let bundle_endpoint = format!("{}fhir/Bundle", self.url);
+        debug!("Fetching new data from: {}", bundle_endpoint);
+        let query = vec![("_lastUpdated", format!("gt{}", last_update))];
+        let response = reqwest::Client::new()
+            .get(bundle_endpoint)
+            .query(&query)
+            .send()
+            .await
+            .map_err(|err| format!("Unable to query data from input server: {}", err))?;
+        response
+            .json::<Bundle>()
+            .await
+            .map_err(|err| format!("Unable to response from input server: {}", err))
+    }
+
+    // post a fhir bundle to a specified fhir server
+    pub async fn post_data(&self, bundle: Bundle) -> Result<reqwest::Response, String> {
+        let bundle_endpoint = format!("{}fhir", self.url);
+        debug!("Posting data to output fhir server: {}", bundle_endpoint);
+        reqwest::Client::new()
+            .post(bundle_endpoint)
+            .json(&bundle)
+            .send()
+            .await
+            .map_err(|err| format!("Unable to post data to output fhir server: {}", err))
+    }
+}
 
 pub trait PseudonymizableExt: Sized {
     fn pseudonymize(self) -> axum::response::Result<Self>;
@@ -23,8 +145,14 @@ impl LinkableExt for Patient {
             .build()
             .map_err(|err| {
                 // TODO: Ensure that this will be a fatal error, as otherwise the linkage will not be possible
-                error!("Unable to add token request to data request. See error message: {}", err);
-                (StatusCode::INTERNAL_SERVER_ERROR, "Unable to add token request to data request")
+                error!(
+                    "Unable to add token request to data request. See error message: {}",
+                    err
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Unable to add token request to data request",
+                )
             })
             .unwrap();
         self.identifier.push(Some(request));
@@ -32,143 +160,58 @@ impl LinkableExt for Patient {
     }
 
     fn get_exchange_identifier(&self) -> Option<&Identifier> {
-       self.identifier.iter().flatten().find(
-           |x| x.system.as_ref() == Some(&CONFIG.exchange_id_system)
-       )
+        self.identifier
+            .iter()
+            .flatten()
+            .find(|x| x.system.as_ref() == Some(&CONFIG.exchange_id_system))
     }
 
     fn contains_exchange_identifier(&self) -> bool {
-        self.identifier.iter().flatten().any(
-            |x| x.system.as_ref() == Some(&CONFIG.exchange_id_system)
-        )
+        self.identifier
+            .iter()
+            .flatten()
+            .any(|x| x.system.as_ref() == Some(&CONFIG.exchange_id_system))
     }
 }
 
 impl PseudonymizableExt for Patient {
     fn pseudonymize(self) -> axum::response::Result<Self> {
         let id = self.id.clone().unwrap();
-        let exchange_identifier_pos = self.identifier.iter().position(
-            |x| x.clone().is_some_and(|y| y.system == Some(CONFIG.exchange_id_system.clone()))
-        ).unwrap();
-        let exchange_identifier  = self.identifier.get(exchange_identifier_pos).cloned();
+        let exchange_identifier_pos = self
+            .identifier
+            .iter()
+            .position(|x| {
+                x.clone()
+                    .is_some_and(|y| y.system == Some(CONFIG.exchange_id_system.clone()))
+            })
+            .unwrap();
+        let exchange_identifier = self.identifier.get(exchange_identifier_pos).cloned();
         let pseudonymized_patient = Patient::builder()
             .id(id)
-            .identifier(vec![
-                exchange_identifier.unwrap()
-            ])
+            .identifier(vec![exchange_identifier.unwrap()])
             .build()
-            .map_err(|err|
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Unable to create pseudonymized patient object {}", err)))?;
+            .map_err(|err| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Unable to create pseudonymized patient object {}", err),
+                )
+            })?;
         Ok(pseudonymized_patient)
-    }
-}
-
-pub async fn post_data_request(
-    fhir_endpoint: &Url,
-    _fhir_api_key: &String,
-    patient: Patient,
-    consent: Consent
-) -> Result<String, (StatusCode, &'static str)> {
-    let bundle_endpoint = format!("{}fhir", fhir_endpoint);
-    debug!("Posting request for DIC to {}", fhir_endpoint);
-
-    let patient_entry = BundleEntry::builder()
-        .resource(Resource::from(patient))
-        .request(
-            BundleEntryRequest::builder()
-                .method(fhir_sdk::r4b::codes::HTTPVerb::Post)
-                .url(String::from("/Patient"))
-                .build().unwrap()
-            ).build().unwrap();
-
-    let consent_entry = BundleEntry::builder()
-        .resource(Resource::from(consent))
-        .request(
-            BundleEntryRequest::builder()
-            .method(fhir_sdk::r4b::codes::HTTPVerb::Post)
-            .url(String::from("/Consent"))
-            .build().unwrap()
-        ).build().unwrap();
-
-    let payload_bundle = Bundle::builder()
-        .r#type(fhir_sdk::r4b::codes::BundleType::Transaction)
-        .entry(
-            vec![
-                Some(patient_entry),
-                Some(consent_entry)
-            ]
-        ).build().unwrap();
-
-    let response = reqwest::Client::new().post(bundle_endpoint)
-    .header(header::CONTENT_TYPE, "application/json+fhir")
-    .json(&payload_bundle)
-    .send()
-    .await.map_err(|err | {
-        warn!("Unable to connect to fhir server: {}", err);
-        (StatusCode::SERVICE_UNAVAILABLE, "Unable to connect to consent fhir server. Please try later.")
-    }).unwrap();
-
-    if response.status().is_client_error() | response.status().is_server_error() {
-        error!("Unable to push request to server: status={}", response.status());
-        return Err((StatusCode::BAD_GATEWAY, "Unable to create consent in consent server. Please contact your administrator."))
-    };
-
-    let bundle = response.json::<Bundle>()
-        .await
-        .map_err(|err| {
-            error!("Unable to parse consent returned by fhir server: {}", err);
-            (StatusCode::BAD_GATEWAY, "Unable to parse consent returned by consent server. Please contact your administrator.")
-        }).unwrap(); 
-
-    Ok(bundle.id.clone().expect("Consent Server returned bundle without id."))
-}
-
-// get data from fhir server that updated after a specified date
-pub async fn pull_new_data(fhir_endpoint: &Url, last_update: NaiveDate) -> Result<Bundle, String> {
-    let bundle_endpoint = format!("{}fhir/Bundle", fhir_endpoint);
-    debug!("Fetching new data from: {}", bundle_endpoint);
-    let query = vec![
-        ("_lastUpdated", format!("gt{}", last_update))
-    ];
-    let response = reqwest::Client::new()
-        .get(bundle_endpoint)
-        .query(&query)
-        .send()
-        .await
-        .map_err(|err| {
-            format!("Unable to query data from input server: {}", err)
-        })?;
-        response.json::<Bundle>()
-        .await
-        .map_err(|err| {
-            format!("Unable to response from input server: {}", err)
-        })
-}
-
-// post a fhir bundle to a specified fhir server
-pub async fn post_data(fhir_endpoint: &Url, bundle: Bundle) -> Result<reqwest::Response, String> {
-    let bundle_endpoint = format!("{}fhir", fhir_endpoint);
-    debug!("Posting data to output fhir server: {}", bundle_endpoint);
-    reqwest::Client::new()
-        .post(bundle_endpoint)
-        .json(&bundle)
-        .send()
-        .await
-        .map_err(|err| {
-            format!("Unable to post data to output fhir server: {}", err)
-        })
+    } 
 }
 
 #[cfg(test)]
 mod tests {
-    use fhir_sdk::r4b::{codes::IdentifierUse, resources::Patient};
     use crate::fhir::LinkableExt;
+    use fhir_sdk::r4b::{codes::IdentifierUse, resources::Patient};
 
     #[test]
     fn add_id_request() {
         let mut patient = Patient::builder().build().unwrap();
         patient = patient.add_id_request("SOME_SYSTEM".to_string()).unwrap();
-        let identifier = patient.identifier[0].as_ref().expect("Add id request didn't add an identifier to empty patient");
+        let identifier = patient.identifier[0]
+            .as_ref()
+            .expect("Add id request didn't add an identifier to empty patient");
         // expect a new identifier with same system as requested
         assert_eq!(identifier.system, Some("SOME_SYSTEM".to_string()));
         // expect the new identifier to have secondary use
@@ -176,5 +219,4 @@ mod tests {
         // expect the new identifier to not have a value
         assert_eq!(identifier.value, None);
     }
-
 }

--- a/src/fhir.rs
+++ b/src/fhir.rs
@@ -161,8 +161,8 @@ pub async fn post_data(fhir_endpoint: &Url, bundle: Bundle) -> Result<reqwest::R
 
 #[cfg(test)]
 mod tests {
-    use fhir_sdk::r4b::{codes::IdentifierUse, resources::Patient, types::{HumanName, Identifier}};
-    use crate::{fhir::{LinkableExt, PseudonymizableExt}, CONFIG};
+    use fhir_sdk::r4b::{codes::IdentifierUse, resources::Patient};
+    use crate::fhir::LinkableExt;
 
     #[test]
     fn add_id_request() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod banner;
 mod config;
 mod fhir;
 mod requests;
-mod mainzelliste;
+mod ttp;
 
 static CONFIG: Lazy<Config> = Lazy::new(Config::parse);
 static SERVER_ADDRESS: &str = "0.0.0.0:8080";
@@ -151,10 +151,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-    }
-
-    async fn fetch_data() {
-        todo!()
     }
     
 }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -62,7 +62,10 @@ pub async fn create_data_request(
     patient = patient.pseudonymize()?;
     consent = link_patient_consent(&consent, &patient)?;
     // und in beiden fällen anschließend die Anfrage beim Datenintegrationszentrum abgelegt werden 
-    let data_request_id = REQUEST_SERVER.post_data_request(patient, consent).await?;
+    let data_request_id = REQUEST_SERVER.post_data_request(DataRequestPayload {
+        patient,
+        consent
+    }).await?;
 
     let data_request = DataRequest {
         id: dbg!(data_request_id),

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -7,7 +7,7 @@ use serde::{Serialize, Deserialize};
 use sqlx::{Pool, Sqlite};
 use tracing::{trace, debug, error};
 
-use crate::{fhir::{FhirServer, LinkableExt, PseudonymizableExt}, CONFIG};
+use crate::{fhir::{FhirServer, PatientExt}, CONFIG};
 
 static REQUEST_SERVER: Lazy<FhirServer> = Lazy::new(|| {
     FhirServer {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -1,12 +1,12 @@
 use axum::{extract::{Path, State}, Json};
 
-use fhir_sdk::r4b::{resources::{Consent, Patient}, types::{Identifier, Reference}};
+use fhir_sdk::r4b::{resources::{Consent, Patient}, types::Reference};
 use reqwest::StatusCode;
 use serde::{Serialize, Deserialize};
 use sqlx::{Pool, Sqlite};
 use tracing::{trace, debug, error};
 
-use crate::{fhir::post_data_request, mainzelliste::{request_project_pseudonym, document_patient_consent}, CONFIG};
+use crate::{fhir::{post_data_request, LinkableExt, PseudonymizableExt}, mainzelliste::{request_project_pseudonym, document_patient_consent}, CONFIG};
 
 #[derive(Serialize, Deserialize, sqlx::Type)]
 pub enum RequestStatus {
@@ -26,16 +26,6 @@ pub struct DataRequest {
 pub struct DataRequestPayload {
     pub patient: Patient,
     pub consent: Consent
-}
-
-pub trait LinkableExt: Sized {
-    fn add_id_request(self, id: String) -> axum::response::Result<Self>;
-    fn get_exchange_identifier(&self) -> Option<&Identifier>;
-    fn contains_exchange_identifier(&self) -> bool;
-}
-
-pub trait PseudonymizableExt: Sized {
-    fn pseudonymize(self) -> axum::response::Result<Self>;
 }
 
 // POST /requests; Creates a new Data Request

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -6,7 +6,7 @@ use serde::{Serialize, Deserialize};
 use sqlx::{Pool, Sqlite};
 use tracing::{trace, debug, error};
 
-use crate::{fhir::{post_data_request, LinkableExt, PseudonymizableExt}, mainzelliste::{request_project_pseudonym, document_patient_consent}, CONFIG};
+use crate::{fhir::{post_data_request, LinkableExt, PseudonymizableExt}, CONFIG};
 
 #[derive(Serialize, Deserialize, sqlx::Type)]
 pub enum RequestStatus {
@@ -39,9 +39,9 @@ pub async fn create_data_request(
         patient = patient
           .add_id_request(CONFIG.exchange_id_system.clone())?
           .add_id_request(ttp.project_id_system.clone())?;
-        patient = request_project_pseudonym(&mut patient, &ttp).await?;
+        patient = ttp.request_project_pseudonym(&mut patient).await?;
         trace!("TTP Returned these patient with project pseudonym {:#?}", &patient);
-        consent = document_patient_consent(consent, &patient, &ttp).await?;
+        consent = ttp.document_patient_consent(consent, &patient).await?;
         trace!("TTP returned this consent for Patient {:?}", consent);
     } else {
         // ohne) das vorhandensein des linkbaren Pseudonym überprüft werden (identifier existiert, eventuell mit Wert in Konfiguration abgleichen?)

--- a/src/ttp.rs
+++ b/src/ttp.rs
@@ -1,0 +1,70 @@
+mod mainzelliste;
+
+use clap::{Args, ValueEnum};
+use fhir_sdk::r4b::resources::{Consent, Patient};
+use reqwest::{StatusCode, Url};
+use serde::{Deserialize, Serialize};
+
+#[derive(Args, Clone, Debug)]
+#[group(requires = "url", requires = "api_key", requires = "project_id_system")]
+pub struct Ttp {
+    #[arg(
+        required = false,
+        long = "institute-ttp-url",
+        env = "INSTITUTE_TTP_URL"
+    )]
+    pub url: Url,
+    #[arg(
+        required = false,
+        long = "institute-ttp-api-key",
+        env = "INSTITUTE_TTP_API_KEY"
+    )]
+    pub api_key: String,
+
+    // defines the identifier to safe in the project database
+    #[arg(required = false, long, env)]
+    pub project_id_system: String,
+
+    #[arg(required = false, long, env, default_value = "mainzelliste")]
+    pub ttp_type: TtpType,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum TtpType {
+    Mainzelliste,
+}
+
+impl Ttp {
+    pub async fn check_availability(&self) -> bool {
+        match self.ttp_type {
+            TtpType::Mainzelliste => mainzelliste::check_availability(self).await,
+        }
+    }
+
+    pub async fn check_idtype_available(&self, idtype: &str) -> bool {
+        match self.ttp_type {
+            TtpType::Mainzelliste => mainzelliste::check_idtype_available(self, idtype).await,
+        }
+    }
+
+    pub async fn document_patient_consent(
+        &self,
+        consent: Consent,
+        patient: &Patient,
+    ) -> Result<Consent, (StatusCode, &'static str)> {
+        match self.ttp_type {
+            TtpType::Mainzelliste => {
+                mainzelliste::document_patient_consent(consent, patient, self).await
+            }
+        }
+    }
+
+    pub async fn request_project_pseudonym(
+        &self,
+        patient: &mut Patient,
+    ) -> Result<Patient, (StatusCode, &'static str)> {
+        match self.ttp_type {
+            TtpType::Mainzelliste => mainzelliste::request_project_pseudonym(patient, self).await,
+        }
+    }
+}


### PR DESCRIPTION
Organized the code base a bit by
- adding extension traits and implementations for the fhir patient struct to do relevant actions (pseudonymize, add_id_request)
- decoupled the requests interface from mainzelliste implementiation by extending the Ttp struct
- reorganized the different methods in fhir.rs that interact with a fhir server into a struct 