### PR TITLE
Enable basic auth for fhir servers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use clap::Parser;
 use reqwest::Url;
 
@@ -19,15 +21,32 @@ pub struct Config {
     #[clap(long, env)]
     pub fhir_request_url: Url,
     #[clap(long, env)]
-    pub fhir_request_credentials: String,
+    pub fhir_request_credentials: Option<Auth>,
     // Definition of the fhir server and credentials used for reading data from the dic
     #[clap(long, env)]
     pub fhir_input_url: Url,
     #[clap(long, env)]
-    pub fhir_input_credentials: String,
+    pub fhir_input_credentials: Option<Auth>,
     // Definition of the fhir server and credentials used for adding data to the project data
     #[clap(long, env)]
     pub fhir_output_url: Url,
     #[clap(long, env)]
-    pub fhir_output_credentials: String,
+    pub fhir_output_credentials: Option<Auth>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Auth {
+    Basic {
+        user: String,
+        pw: String,
+    },
+}
+
+impl FromStr for Auth {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (user, pw) = s.split_once(":").ok_or("Credentials should be in the form of '<user>:<pw>'")?;
+        Ok(Self::Basic { user: user.to_owned(), pw: pw.to_owned() })
+    }
 }

--- a/src/fhir.rs
+++ b/src/fhir.rs
@@ -1,5 +1,4 @@
 use chrono::NaiveDate;
-use clap::Args;
 use fhir_sdk::r4b::{
     codes::IdentifierUse,
     resources::{Bundle, BundleEntry, BundleEntryRequest, Patient, Resource},
@@ -10,12 +9,9 @@ use tracing::{debug, error, warn};
 
 use crate::{requests::DataRequestPayload, CONFIG};
 
-#[derive(Args, Clone, Debug)]
-#[group(requires = "url", requires = "credentials")]
+#[derive(Clone, Debug)]
 pub struct FhirServer {
-    #[arg(required = false)]
     pub url: Url,
-    #[arg(required = false)]
     pub credentials: String,
 }
 
@@ -41,8 +37,7 @@ impl FhirServer {
                     StatusCode::SERVICE_UNAVAILABLE,
                     "Unable to connect to consent fhir server. Please try later.",
                 )
-            })
-            .unwrap();
+            })?;
 
         if response.status().is_client_error() | response.status().is_server_error() {
             error!(
@@ -60,7 +55,7 @@ impl FhirServer {
             .map_err(|err| {
                 error!("Unable to parse consent returned by fhir server: {}", err);
                 (StatusCode::BAD_GATEWAY, "Unable to parse consent returned by consent server. Please contact your administrator.")
-            }).unwrap();
+            })?;
 
         Ok(bundle
             .id

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,14 +76,14 @@ async fn main() -> ExitCode {
 
     tokio::spawn(async move {
         const RETRY_PERIOD: Duration = Duration::from_secs(60);
-        let input_fhir_server =  FhirServer {
-            url: CONFIG.fhir_input_url.clone(),
-            credentials: CONFIG.fhir_input_credentials.clone()
-        };
-        let output_fhir_server =  FhirServer {
-            url: CONFIG.fhir_output_url.clone(),
-            credentials: CONFIG.fhir_output_credentials.clone()
-        };
+        let input_fhir_server =  FhirServer::new(
+            CONFIG.fhir_input_url.clone(),
+            CONFIG.fhir_input_credentials.clone()
+        );
+        let output_fhir_server =  FhirServer::new (
+            CONFIG.fhir_output_url.clone(),
+            CONFIG.fhir_output_credentials.clone()
+        );
         loop {
             // TODO: Persist the updated data in the database
             match fetch_data(&input_fhir_server, &output_fhir_server).await {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -10,10 +10,7 @@ use tracing::{trace, debug, error};
 use crate::{fhir::{FhirServer, PatientExt}, CONFIG};
 
 static REQUEST_SERVER: Lazy<FhirServer> = Lazy::new(|| {
-    FhirServer {
-        url: CONFIG.fhir_request_url.clone(),
-        credentials: CONFIG.fhir_request_credentials.clone()
-    }
+    FhirServer::new(CONFIG.fhir_request_url.clone(), CONFIG.fhir_request_credentials.clone())
 });
 
 #[derive(Serialize, Deserialize, sqlx::Type)]


### PR DESCRIPTION
Ignore the branch name.

Bummer we dont have https://github.com/seanmonstar/reqwest/pull/1398 yet.
For now I think this is the easiest way we can set the header for the request.
I did not want to depend on some b64 crate to encode it manually to set it in the default header.
Also the enum for `Auth` might be a bit ambitious but it does not really make it more complicated so we might as well have it.