### PR TITLE
fix: treat empty strings as providing no auth

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,22 +20,23 @@ pub struct Config {
     // Definition of the fhir server and credentials used for communicating data requests to the dic
     #[clap(long, env)]
     pub fhir_request_url: Url,
-    #[clap(long, env)]
-    pub fhir_request_credentials: Option<Auth>,
+    #[clap(long, env, default_value = "")]
+    pub fhir_request_credentials: Auth,
     // Definition of the fhir server and credentials used for reading data from the dic
     #[clap(long, env)]
     pub fhir_input_url: Url,
-    #[clap(long, env)]
-    pub fhir_input_credentials: Option<Auth>,
+    #[clap(long, env, default_value = "")]
+    pub fhir_input_credentials: Auth,
     // Definition of the fhir server and credentials used for adding data to the project data
     #[clap(long, env)]
     pub fhir_output_url: Url,
-    #[clap(long, env)]
-    pub fhir_output_credentials: Option<Auth>,
+    #[clap(long, env, default_value = "")]
+    pub fhir_output_credentials: Auth,
 }
 
 #[derive(Debug, Clone)]
 pub enum Auth {
+    None,
     Basic {
         user: String,
         pw: String,
@@ -46,6 +47,9 @@ impl FromStr for Auth {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(Self::None);
+        }
         let (user, pw) = s.split_once(":").ok_or("Credentials should be in the form of '<user>:<pw>'")?;
         Ok(Self::Basic { user: user.to_owned(), pw: pw.to_owned() })
     }

--- a/src/fhir.rs
+++ b/src/fhir.rs
@@ -12,27 +12,25 @@ use crate::{config::Auth, requests::DataRequestPayload, CONFIG};
 #[derive(Clone, Debug)]
 pub struct FhirServer {
     url: Url,
-    auth: Option<Auth>,
+    auth: Auth,
     client: Client,
 }
 
 trait ClientBuilderExt {
-    fn add_auth(self, auth: &Option<Auth>) -> Self;
+    fn add_auth(self, auth: &Auth) -> Self;
 }
 
 impl ClientBuilderExt for reqwest::RequestBuilder {
-    fn add_auth(self, auth: &Option<Auth>) -> Self {
-        let Some(auth) = auth else {
-            return self
-        };
+    fn add_auth(self, auth: &Auth) -> Self {
         match auth {
             Auth::Basic { user, pw } => self.basic_auth(user, Some(pw)),
+            Auth::None => self,
         }
     }
 }
 
 impl FhirServer {
-    pub fn new(url: Url, auth: Option<Auth>) -> Self {
+    pub fn new(url: Url, auth: Auth) -> Self {
         Self { url, auth, client: Client::new() }
     }
     


### PR DESCRIPTION
While I don't like the `default_value = ""` its the best solution I found to make this work nicely with the env vars which docker compose automatically sets to an empty string when not set leading us to parsing empty string in `Auth::from_str` rendering the `Option` useless.