### PR TITLE
refactor!: unify ttp arg naming

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [env]
 # Environment for Routine Connector
-INSTITUTE_TTP_URL="http://localhost:8081"
-INSTITUTE_TTP_API_KEY="routine-connector-password"
+TTP_URL="http://localhost:8081"
+TTP_ML_API_KEY="routine-connector-password"
 FHIR_REQUEST_URL="http://localhost:8085"
 # FHIR_REQUEST_CREDENTIALS="user:pw"
 FHIR_INPUT_URL="http://localhost:8086"

--- a/dev/test
+++ b/dev/test
@@ -8,8 +8,8 @@ function start_bg() {
   trap "echo; echo; docker compose logs; docker compose down" EXIT
 
   # Test Config Setup
-  export INSTITUTE_TTP_URL="http://localhost:8081";
-  export INSTITUTE_TTP_API_KEY="transFAIR-password";
+  export TTP_URL="http://localhost:8081";
+  export TTP_ML_API_KEY="transFAIR-password";
   export PROJECT_ID_SYSTEM="PROJECT_1_ID"
   export FHIR_REQUEST_URL="http://localhost:8085"
   export FHIR_INPUT_URL="http://localhost:8086"

--- a/docs/Referenzimplementierung Transferstelle.org
+++ b/docs/Referenzimplementierung Transferstelle.org
@@ -4,13 +4,13 @@ Die Referenzimplementierung übernimmt die Aufgabe, Daten für eingewilligte Pat
 * Konfigurationsparameter
 Um ihre Aufgabe erfüllen zu können, muss die Transferstelle pro Projekt mit folgenden Parametern konfiguriert werden
 #+PROPERTY: header-args :var
-#+PROPERTY: header-args+ INSTITUTE_TTP_INTERFACE="http://localhost:8081/fhir"
+#+PROPERTY: header-args+ TTP_INTERFACE="http://localhost:8081/fhir"
 #+PROPERTY: header-args+ DIZ_API_KEY="diz-password"
 #+PROPERTY: header-args+ CONSENT_FHIR_INTERFACE="http://localhost:8085/fhir"
 #+PROPERTY: header-args+ MDAT_FHIR_INTERFACE="http://localhost:8086/fhir"
 #+PROPERTY: header-args+ ROUTINE_FHIR_INTERFACE="http://localhost:8090/fhir"
 | Variable                | Beispiel                   | Beschreibung                                                                             |
-| INSTITUTE_TTP_INTERFACE | http://localhost:8081/fhir | Adresse der Schnittstelle der Institutes TTP                                             |
+| TTP_INTERFACE | http://localhost:8081/fhir | Adresse der Schnittstelle der TTPs TTP                                             |
 | DIZ_API_KEY             | diz-password               | Schlüssel mit dem auf die Insitute-TTP zugegriffen werden darf                           |
 | CONSENT_FHIR_INTERFACE  | http://localhost:8085/fhir | Adresse des FHIR-Servers in dem Consent Ressourcen vom Routine Connector abgelegt werden |
 | MDAT_FHIR_INTERFACE     | http://localhost:8086/fhir | Adresse des FHIR-Servers in dem die Transferstelle die Routinedaten ablegt               |
@@ -436,7 +436,7 @@ An dieser Stelle muss die Transferstelle aufgrund der Angaben in den Consents ü
 *** 2.3) Ermittlung zugehöriger DIZ Pseudonyme
 Mit der Extrahierten Liste an SESSION_IDs kann die Transferstelle nun bei der lokalen TTP eine Liste von Patienten abfragen. Dafür muss pro Identifier eine Patientenresource abfragt werden:
 #+begin_src restclient
-POST :INSTITUTE_TTP_INTERFACE/Patient/_search
+POST :TTP_INTERFACE/Patient/_search
 Content-Type: application/x-www-form-urlencoded
 MainzellisteApiKey: :DIZ_API_KEY
 

--- a/docs/Testlauf der Schnittstellen.org
+++ b/docs/Testlauf der Schnittstellen.org
@@ -3,13 +3,13 @@ In diesem Dokument wird ein Testlauf beschrieben, bei dem die einzelnen Schnitts
 
 Für den Testlauf wurden die folgenden Parameter angenommen. Diese entsprechen den Werten aus der beigefügten [[file:docker-compose.yml][docker-compose.yml]]:
 #+PROPERTY: header-args :var
-#+PROPERTY: header-args+ INSTITUTE_TTP_INTERFACE="http://localhost:8081/fhir"
+#+PROPERTY: header-args+ TTP_INTERFACE="http://localhost:8081/fhir"
 #+PROPERTY: header-args+ ROUTINE_CONNECTOR_API_KEY="routine-connector-password"
 #+PROPERTY: header-args+ CONSENT_FHIR_INTERFACE="http://localhost:8085/fhir"
 #+PROPERTY: header-args+ MDAT_FHIR_INTERFACE="http://localhost:8086/fhir"
 #+PROPERTY: header-args+ PROJECT_FHIR_INTERFACE="http://localhost:8095/fhir"
 | Variable                  | Beispiel                   | Beschreibung                                                  |
-| INSTITUTE_TTP_INTERFACE   | http://localhost:8081/fhir | Adresse der Schnittstelle der lokalen Instituts-TTP           |
+| TTP_INTERFACE   | http://localhost:8081/fhir | Adresse der Schnittstelle der lokalen Instituts-TTP           |
 | ROUTINE_CONNECTOR_API_KEY | routine-connector-password | Schlüssel zur Authentifizierung bei der lokalen Instituts-TTP |
 | CONSENT_FHIR_INTERFACE    | http://localhost:8085/fhir |                                                               |
 | MDAT_FHIR_INTERFACE       | http://localhost:8086/fhir |                                                               |
@@ -21,7 +21,7 @@ Die Funktionen der Stand
 Zu Beginn erzeugt der Routine Connector bei der Standort-TTP (in diesem Fall eine Mainzelliste) ein neues Projekt bezogenes Patientenpseudonym.
 #+NAME: patient-fhir-data
 #+begin_src restclient :results value
-POST :INSTITUTE_TTP_INTERFACE/Patient
+POST :TTP_INTERFACE/Patient
 Content-Type: application/fhir+json
 mainzellisteApiKey: :ROUTINE_CONNECTOR_API_KEY
 
@@ -136,7 +136,7 @@ echo "$data" | jq -c '[.identifier[] | select(.system | contains("PROJECT_1_ID")
 ** TODO 1.3) Dokumentation des Consents in Standort-TTP
 Das Consent des Patienten wird zu Dokumentationszwecken auch in der Standort-TTP hinterlegt. Der Routine Connector erhält die FHIR Resource hierfür als Input und ergänzt nur den bereits aus 1.2 bekannten Session Identifier.
 #+begin_src restclient :var session_id=session-id-from-fhir
-POST :INSTITUTE_TTP_INTERFACE/Consent
+POST :TTP_INTERFACE/Consent
 Content-Type: application/fhir+json
 
 {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -31,8 +31,8 @@
         devShells.default = pkgs.mkShell {
           inherit buildInputs nativeBuildInputs;
           # Environment for Routine Connector
-          INSTITUTE_TTP_URL = "http://localhost:8081";
-          INSTITUTE_TTP_API_KEY = "routine-connector-password";
+          TTP_URL = "http://localhost:8081";
+          TTP_ML_API_KEY = "routine-connector-password";
           FHIR_REQUEST_URL = "http://localhost:8085";
           # FHIR_REQUEST_CREDENTIALS = "bla:test";
           FHIR_INPUT_URL = "http://localhost:8086";

--- a/src/ttp.rs
+++ b/src/ttp.rs
@@ -14,8 +14,8 @@ use crate::config::Auth;
 #[derive(Parser, Debug, Clone)]
 pub struct TtpInner {
     #[clap(
-        long = "institute-ttp-url",
-        env = "INSTITUTE_TTP_URL"
+        long = "ttp-url",
+        env = "TTP_URL"
     )]
     pub url: Url,
 
@@ -23,7 +23,11 @@ pub struct TtpInner {
     #[clap(long, env)]
     pub project_id_system: String,
 
-    #[clap(long, env, default_value = "")]
+    #[clap(
+        long = "ttp-auth",
+        env = "TTP_AUTH",
+        default_value = ""
+    )]
     pub ttp_auth: Auth,
 
     #[clap(skip)]

--- a/src/ttp/greifswald.rs
+++ b/src/ttp/greifswald.rs
@@ -19,7 +19,12 @@ pub struct GreifswaldConfig {
     #[clap(flatten)]
     pub base: super::TtpInner,
 
-    #[clap(long, env, default_value = "transfair")]
+
+    #[clap(
+        long = "ttp-gw-source",
+        env = "TTP_GW_SOURCE",
+        default_value = "transfair"
+    )]
     source: String,
 }
 

--- a/src/ttp/mainzelliste.rs
+++ b/src/ttp/mainzelliste.rs
@@ -11,8 +11,8 @@ pub struct MlConfig {
     pub base: super::TtpInner,
 
     #[clap(
-        long = "institute-ttp-api-key",
-        env = "INSTITUTE_TTP_API_KEY"
+        long = "ttp-ml-api-key",
+        env = "TTP_ML_API_KEY"
     )]
     pub api_key: String,
 }


### PR DESCRIPTION
We don't really need this breaking change but I think the naming makes much more sense that way. Do we have transfair deployed anywhere where this would break anything? Also while we are at it to we want to cut the `INSTITUTE` in front of all these vars while we are at it?