### PR TITLE
refactor: switch to fhirbolt

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [env]
 # Environment for Routine Connector
-TTP_URL="http://localhost:8081"
-TTP_ML_API_KEY="routine-connector-password"
+TTP_URL="http://localhost:8082"
+TTP_ML_API_KEY="transFAIR-password"
 FHIR_REQUEST_URL="http://localhost:8085"
 # FHIR_REQUEST_CREDENTIALS="user:pw"
 FHIR_INPUT_URL="http://localhost:8086"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 axum = "0.8.1"
 chrono = { version = "0.4.37", default-features = false, features = ["serde", "now"] }
 clap = { version = "4.5.3", features = ["env", "derive"] }
-fhir-sdk = { version = "0.14.1", default-features = false, features = ["builders", "r4b"] }
+fhirbolt = { version = "0.4", features = ["r4b"] }
 futures-util = { version = "0.3", default-features = false }
 once_cell = "1.19.0"
 reqwest = { version = "0.12.2", features = ["json", "rustls-tls"], default-features = false }

--- a/a.json
+++ b/a.json
@@ -1,0 +1,22 @@
+{
+    "type": "transaction",
+    "resourceType": "Bundle",
+    "entry": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "/Patient"
+            },
+            "resource": {
+                "resourceType": "Patient",
+                "identifier": []
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "/Consent"
+            }
+        }
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,18 +37,18 @@ services:
 
   # This service will normaly be provided by the bridgehead, but could also be just a fhir server hosted by the authority for data transfer
   consent-fhir-server:
-    image: samply/blaze
+    image: samply/blaze:0.34
     ports:
       - 8085:8080
 
   # This service will normaly be provided by the bridgehead, but could also be just a fhir server hosted by the authority for data transfer
   mdat-fhir-server:
-    image: samply/blaze
+    image: samply/blaze:0.34
     ports:
       - 8086:8080
 
   # This service reprents a specific projects database
   project-data-fhir-server:
-    image: samply/blaze
+    image: samply/blaze:0.34
     ports:
       - 8095:8080

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,4 +376,12 @@ mod tests {
             assert_ne!(identifier.value.unwrap().value.as_ref(), Some(&data_request.exchange_id));
         };
     }
+
+    #[test]
+    fn asfd() -> anyhow::Result<()> {
+        let bytes = include_bytes!("../a.json");
+        let data_request: Bundle = fhirbolt::json::from_slice(bytes, None)?;
+        dbg!(data_request);
+        Ok(())
+    }
 }

--- a/src/ttp.rs
+++ b/src/ttp.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use axum::response::IntoResponse;
 use clap::{FromArgMatches, Parser, ValueEnum};
-use fhir_sdk::r4b::resources::{Consent, Patient};
+use fhirbolt::model::r4b::resources::{Consent, Patient};
 use reqwest::{Client, StatusCode, Url};
 use thiserror::Error;
 


### PR DESCRIPTION
Lets see if tests still pass

Motivation being that if we need to support soap we need to serialize to xml. Also this lib is a bit more light weight as it does not generate types for every coding. So compile times might improve a bit as well and I like this api more than the builder stuff the other lib is doing.

Disadvantage I needed to write some sketchy serde logic I am not 100% confident about