### PR TITLE
chore: release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0 - 2025-27-08]
+
+- CLI changes
+- Support for [greifswald tools](https://www.ths-greifswald.de/) as a TTP
+- Bug fixes
+
 ## [1.0.0 - 2025-02-06]
 
 Initial release. Contains following features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfair"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
We need to do a github release because bridgehead uses latest tag and our new CI does not update that unless we push a tag. So lets cut a release so the bridgeheads actually update to the new subcommand changes and dont crash.